### PR TITLE
Update site - long overdue!

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,27 @@
+source "https://rubygems.org"
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "3.5.0"
+
+# This is the default theme for new Jekyll sites. You may change this to anything you like.
+gem "minima", "~> 2.0"
+
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+   gem "jekyll-feed", "~> 0.6"
+end
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,58 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    jekyll (3.5.0)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-feed (0.9.2)
+      jekyll (~> 3.3)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.14.0)
+    liquid (4.0.0)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    minima (2.1.1)
+      jekyll (~> 3.3)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (2.0.5)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (1.11.1)
+    safe_yaml (1.0.4)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (= 3.5.0)
+  jekyll-feed (~> 0.6)
+  minima (~> 2.0)
+  tzinfo-data
+
+BUNDLED WITH
+   1.15.1

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: WPupdatePHP
 email: coenjacobs@gmail.com
 description: > # this means to ignore newlines until "baseurl:"
   PHP library to be bundled with WordPress plugins
-  to enforce users to upgrade to PHP 5.4 or higher hosting.
+  to enforce users to upgrade to hosting on supported PHP versions.
 baseurl: ""
 url: "http://www.wpupdatephp.com"
 twitter_username: WPupdatePHP

--- a/about.md
+++ b/about.md
@@ -4,7 +4,7 @@ title: About
 permalink: /about/
 ---
 
-WPupdatePHP is a PHP library to be bundled with WordPress plugins to enforce users to upgrade to PHP 5.4 or higher hosting.
+WPupdatePHP is a PHP library to be bundled with WordPress plugins to enforce users to upgrade to PHP 5.6 or higher hosting.
 
 ## Why we do this
 The developers of the affiliated plugins no longer want to support these old versions of PHP.

--- a/contact-host.md
+++ b/contact-host.md
@@ -6,12 +6,12 @@ permalink: /contact-host/
 
 Contacting your hosting company is usually the easiest way to find out how you can update your PHP version. They probably already have newer PHP versions available, they just need to update your account.
 
-You will have to ask them to be updated to a currently supported PHP version. At this moment, it's safe to run on PHP 5.4, but it doesn't hurt to get updated to PHP 5.5 or higher already.
+You will have to ask them to be updated to a currently supported PHP version. At this moment, it's safe to run on PHP 5.6, but it doesn't hurt to get updated to PHP 7 or higher already.
 
 Here’s a letter you can send to your host:
 
-> For the plugin I want to use on my WordPress website, there is a requirement of PHP 5.4. WordPress has also listed this version as the recommended PHP version on their [requirements page](https://wordpress.org/about/requirements/).
+> For the plugin I want to use on my WordPress website, there is a requirement of PHP 5.6. WordPress has also listed this version as the recommended PHP version on their [requirements page](https://wordpress.org/about/requirements/).
 >
 > You can find more information about this version requirement on the [WPupdatePHP website](http://www.wpupdatephp.com/).
 >
-> Can you please let me know if my hosting supports PHP 5.4 and how I can upgrade? Thanks!
+> Can you please let me know if my hosting supports PHP 5.6 and how I can upgrade? Thanks!

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@ layout: default
 <div class="home">
   <h1>WPupdatePHP: Time to update your PHP version</h1>
   <p>This library and website aim to get everyone updated to at least a <a href="http://php.net/supported-versions.php">supported version of PHP</a>.</p>
-  <p>WordPress has PHP 5.2.4 as the <a href="https://wordpress.org/about/requirements/">minimum required version</a>. This is a version that has been unsupported since early 2011. The PHP 5.3.* versions have been unsupported since August 2014 as well. This means that these versions don't receive any updates, which leaves them potentially insecure.</p>
-  <p>PHP 5.4 is now the recommended version for WordPress, so we can actively start to ask hosts to update their PHP versions. This library helps you do that.</p>
+  <p>WordPress has PHP 5.2.4 as the <a href="https://wordpress.org/about/requirements/">minimum required version</a>. This is a version that has been unsupported since early 2011. All PHP versions below 5.6 are currently no longer supported. This means that these versions don't receive any updates, which leaves them potentially insecure.</p>
+  <p>PHP 7+ is now the recommended version for WordPress, so we can actively start to ask hosts to update their PHP versions. This library helps you do that.</p>
 
   <h2>For non-developers</h2>
   <p>If you are not a developer, you should read our <a href="/update/">Time to update</a> page.</p>


### PR DESCRIPTION
Copy now also reflects the lowest maintained PHP version, with an extra push towards PHP 7+ already, as that is now also being shown in the .org minimum requirements.